### PR TITLE
Latest - Voice Updates - Closed For Now - see https://github.com/shikhir-arora/NadekoBot/issues/32

### DIFF
--- a/src/NadekoBot/Modules/Administration/Administration.cs
+++ b/src/NadekoBot/Modules/Administration/Administration.cs
@@ -11,7 +11,6 @@ using Discord.WebSocket;
 using NadekoBot.Services.Database.Models;
 using static NadekoBot.Modules.Permissions.Permissions;
 using System.Collections.Concurrent;
-using Microsoft.EntityFrameworkCore;
 using NLog;
 
 namespace NadekoBot.Modules.Administration
@@ -99,6 +98,10 @@ namespace NadekoBot.Modules.Administration
         [RequireBotPermission(GuildPermission.ManageRoles)]
         public async Task Setrole(IGuildUser usr, [Remainder] IRole role)
         {
+            var guser = (IGuildUser)Context.User;
+            var maxRole = guser.GetRoles().Max(x => x.Position);
+            if (maxRole < role.Position || maxRole <= usr.GetRoles().Max(x => x.Position))
+                return;
             try
             {
                 await usr.AddRolesAsync(role).ConfigureAwait(false);
@@ -118,6 +121,9 @@ namespace NadekoBot.Modules.Administration
         [RequireBotPermission(GuildPermission.ManageRoles)]
         public async Task Removerole(IGuildUser usr, [Remainder] IRole role)
         {
+            var guser = (IGuildUser)Context.User;
+            if (Context.User.Id != guser.Guild.OwnerId && guser.GetRoles().Max(x => x.Position) <= usr.GetRoles().Max(x => x.Position))
+                return;
             try
             {
                 await usr.RemoveRolesAsync(role).ConfigureAwait(false);
@@ -135,6 +141,9 @@ namespace NadekoBot.Modules.Administration
         [RequireBotPermission(GuildPermission.ManageRoles)]
         public async Task RenameRole(IRole roleToEdit, string newname)
         {
+            var guser = (IGuildUser)Context.User;
+            if (Context.User.Id != guser.Guild.OwnerId && guser.GetRoles().Max(x => x.Position) <= roleToEdit.Position)
+                return;
             try
             {
                 if (roleToEdit.Position > (await Context.Guild.GetCurrentUserAsync().ConfigureAwait(false)).GetRoles().Max(r => r.Position))
@@ -157,9 +166,14 @@ namespace NadekoBot.Modules.Administration
         [RequireBotPermission(GuildPermission.ManageRoles)]
         public async Task RemoveAllRoles([Remainder] IGuildUser user)
         {
+            var guser = (IGuildUser)Context.User;
+
+            var userRoles = user.GetRoles();
+            if (guser.Id != Context.Guild.OwnerId && (user.Id == Context.Guild.OwnerId || guser.GetRoles().Max(x => x.Position) <= userRoles.Max(x => x.Position)))
+                return;
             try
             {
-                await user.RemoveRolesAsync(user.GetRoles()).ConfigureAwait(false);
+                await user.RemoveRolesAsync(userRoles).ConfigureAwait(false);
                 await ReplyConfirmLocalized("rar", Format.Bold(user.ToString())).ConfigureAwait(false);
             }
             catch

--- a/src/NadekoBot/Modules/Administration/Administration.cs
+++ b/src/NadekoBot/Modules/Administration/Administration.cs
@@ -169,7 +169,8 @@ namespace NadekoBot.Modules.Administration
             var guser = (IGuildUser)Context.User;
 
             var userRoles = user.GetRoles();
-            if (guser.Id != Context.Guild.OwnerId && (user.Id == Context.Guild.OwnerId || guser.GetRoles().Max(x => x.Position) <= userRoles.Max(x => x.Position)))
+            if (guser.Id != Context.Guild.OwnerId && 
+                (user.Id == Context.Guild.OwnerId || guser.GetRoles().Max(x => x.Position) <= userRoles.Max(x => x.Position)))
                 return;
             try
             {

--- a/src/NadekoBot/Modules/Administration/Commands/AutoAssignRoleCommands.cs
+++ b/src/NadekoBot/Modules/Administration/Commands/AutoAssignRoleCommands.cs
@@ -1,6 +1,7 @@
 ﻿using Discord;
 using Discord.Commands;
 using NadekoBot.Attributes;
+using NadekoBot.Extensions;
 using NadekoBot.Services;
 using NLog;
 using System;
@@ -48,6 +49,11 @@ namespace NadekoBot.Modules.Administration
             [RequireUserPermission(GuildPermission.ManageRoles)]
             public async Task AutoAssignRole([Remainder] IRole role = null)
             {
+                var guser = (IGuildUser)Context.User;
+                if (role != null)
+                    if (Context.User.Id != guser.Guild.OwnerId && guser.GetRoles().Max(x => x.Position) <= role.Position)
+                        return;
+
                 using (var uow = DbHandler.UnitOfWork())
                 {
                     var conf = uow.GuildConfigs.For(Context.Guild.Id, set => set);

--- a/src/NadekoBot/Modules/Administration/Commands/SelfAssignedRolesCommand.cs
+++ b/src/NadekoBot/Modules/Administration/Commands/SelfAssignedRolesCommand.cs
@@ -43,6 +43,10 @@ namespace NadekoBot.Modules.Administration
             {
                 IEnumerable<SelfAssignedRole> roles;
 
+                var guser = (IGuildUser)Context.User;
+                if (Context.User.Id != guser.Guild.OwnerId && guser.GetRoles().Max(x => x.Position) <= role.Position)
+                    return;
+
                 string msg;
                 var error = false;
                 using (var uow = DbHandler.UnitOfWork())
@@ -75,6 +79,10 @@ namespace NadekoBot.Modules.Administration
             [RequireUserPermission(GuildPermission.ManageRoles)]
             public async Task Rsar([Remainder] IRole role)
             {
+                var guser = (IGuildUser)Context.User;
+                if (Context.User.Id != guser.Guild.OwnerId && guser.GetRoles().Max(x => x.Position) <= role.Position)
+                    return;
+
                 bool success;
                 using (var uow = DbHandler.UnitOfWork())
                 {

--- a/src/NadekoBot/Modules/Searches/Commands/Models/TimeModels.cs
+++ b/src/NadekoBot/Modules/Searches/Commands/Models/TimeModels.cs
@@ -1,0 +1,42 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NadekoBot.Modules.Searches.Commands.Models
+{
+    public class TimeZoneResult
+    {
+        public double DstOffset { get; set; }
+        public double RawOffset { get; set; }
+
+        //public string TimeZoneId { get; set; }
+        public string TimeZoneName { get; set; }
+    }
+
+    public class GeolocationResult
+    {
+
+        public class GeolocationModel
+        {
+            public class GeometryModel
+            {
+                public class LocationModel
+                {
+                    public float Lat { get; set; }
+                    public float Lng { get; set; }
+                }
+
+                public LocationModel Location { get; set; }
+            }
+
+            [JsonProperty("formatted_address")]
+            public string FormattedAddress { get; set; }
+            public GeometryModel Geometry { get; set; }
+        }
+
+        public GeolocationModel[] results;
+    }
+}

--- a/src/NadekoBot/Modules/Utility/Utility.cs
+++ b/src/NadekoBot/Modules/Utility/Utility.cs
@@ -16,6 +16,7 @@ using System.Collections.Generic;
 using Newtonsoft.Json;
 using Discord.WebSocket;
 using NadekoBot.Services;
+using System.Diagnostics;
 
 namespace NadekoBot.Modules.Utility
 {
@@ -493,6 +494,17 @@ namespace NadekoBot.Modules.Utility
                 });
             await Context.User.SendFileAsync(
                 await JsonConvert.SerializeObject(grouping, Formatting.Indented).ToStream().ConfigureAwait(false), title, title).ConfigureAwait(false);
+        }
+        [NadekoCommand, Usage, Description, Aliases]
+        [RequireContext(ContextType.Guild)]
+        public async Task Ping()
+        {
+            var sw = Stopwatch.StartNew();
+            var msg = await Context.Channel.SendMessageAsync("🏓").ConfigureAwait(false);
+            sw.Stop();
+            msg.DeleteAfter(0);
+
+            await Context.Channel.SendConfirmAsync($"{Format.Bold(Context.User.ToString())} 🏓 {(int)sw.Elapsed.TotalMilliseconds}ms").ConfigureAwait(false);
         }
     }
 }

--- a/src/NadekoBot/Resources/CommandStrings.Designer.cs
+++ b/src/NadekoBot/Resources/CommandStrings.Designer.cs
@@ -5379,6 +5379,33 @@ namespace NadekoBot.Resources {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to ping.
+        /// </summary>
+        public static string ping_cmd {
+            get {
+                return ResourceManager.GetString("ping_cmd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Ping the bot to see if there are latency issues..
+        /// </summary>
+        public static string ping_desc {
+            get {
+                return ResourceManager.GetString("ping_desc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to `{0}ping`.
+        /// </summary>
+        public static string ping_usage {
+            get {
+                return ResourceManager.GetString("ping_usage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to place.
         /// </summary>
         public static string place_cmd {

--- a/src/NadekoBot/Resources/CommandStrings.Designer.cs
+++ b/src/NadekoBot/Resources/CommandStrings.Designer.cs
@@ -5757,7 +5757,7 @@ namespace NadekoBot.Resources {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar quoteid qid.
+        ///    Looks up a localized string similar to quoteid qid.
         /// </summary>
         public static string quoteid_cmd {
             get {
@@ -8264,6 +8264,33 @@ namespace NadekoBot.Resources {
         public static string tictactoe_usage {
             get {
                 return ResourceManager.GetString("tictactoe_usage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to time.
+        /// </summary>
+        public static string time_cmd {
+            get {
+                return ResourceManager.GetString("time_cmd", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to Shows the current time and timezone in the specified location..
+        /// </summary>
+        public static string time_desc {
+            get {
+                return ResourceManager.GetString("time_desc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///    Looks up a localized string similar to `{0}time London, UK`.
+        /// </summary>
+        public static string time_usage {
+            get {
+                return ResourceManager.GetString("time_usage", resourceCulture);
             }
         }
         

--- a/src/NadekoBot/Resources/CommandStrings.resx
+++ b/src/NadekoBot/Resources/CommandStrings.resx
@@ -1152,7 +1152,7 @@
   <data name="searchquote_usage" xml:space="preserve">
     <value>`{0}qsearch keyword text`</value>
   </data>
-    <data name="quoteid_cmd" xml:space="preserve">
+  <data name="quoteid_cmd" xml:space="preserve">
     <value>quoteid qid</value>
   </data>
   <data name="quoteid_desc" xml:space="preserve">
@@ -3356,5 +3356,14 @@
   </data>
   <data name="slowmodewhitelist_usage" xml:space="preserve">
     <value>`{0}slowmodewl SomeRole` or `{0}slowmodewl AdminDude`</value>
+  </data>
+  <data name="time_cmd" xml:space="preserve">
+    <value>time</value>
+  </data>
+  <data name="time_desc" xml:space="preserve">
+    <value>Shows the current time and timezone in the specified location.</value>
+  </data>
+  <data name="time_usage" xml:space="preserve">
+    <value>`{0}time London, UK`</value>
   </data>
 </root>

--- a/src/NadekoBot/Resources/CommandStrings.resx
+++ b/src/NadekoBot/Resources/CommandStrings.resx
@@ -3330,6 +3330,15 @@
   <data name="claimpatreonrewards_usage" xml:space="preserve">
     <value>`{0}claimpatreonrewards`</value>
   </data>
+  <data name="ping_cmd" xml:space="preserve">
+    <value>ping</value>
+  </data>
+  <data name="ping_desc" xml:space="preserve">
+    <value>Ping the bot to see if there are latency issues.</value>
+  </data>
+  <data name="ping_usage" xml:space="preserve">
+    <value>`{0}ping`</value>
+  </data>
   <data name="slowmodewhitelist_cmd" xml:space="preserve">
     <value>slowmodewl</value>
   </data>

--- a/src/NadekoBot/Resources/ResponseStrings.Designer.cs
+++ b/src/NadekoBot/Resources/ResponseStrings.Designer.cs
@@ -5774,6 +5774,15 @@ namespace NadekoBot.Resources {
         }
         
         /// <summary>
+        ///    Looks up a localized string similar to Time in {0} is {1} - {2}.
+        /// </summary>
+        public static string searches_time {
+            get {
+                return ResourceManager.GetString("searches_time", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///    Looks up a localized string similar to Title:.
         /// </summary>
         public static string searches_title {
@@ -6498,20 +6507,11 @@ namespace NadekoBot.Resources {
         }
         
         /// <summary>
-        ///    Looks up a localized string similar to No quotes on this page..
+        ///    Looks up a localized string similar to No quotes found matching the quote ID specified..
         /// </summary>
         public static string utility_quotes_page_none {
             get {
                 return ResourceManager.GetString("utility_quotes_page_none", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///    Looks up a localized string similar to No quotes found matching the quote ID specified..
-        /// </summary>
-        public static string utility_quotes_notfound {
-            get {
-                return ResourceManager.GetString("utility_quotes_notfound", resourceCulture);
             }
         }
         

--- a/src/NadekoBot/Resources/ResponseStrings.resx
+++ b/src/NadekoBot/Resources/ResponseStrings.resx
@@ -2082,10 +2082,7 @@ Owner ID: {2}</value>
     <value>Page {0} of quotes</value>
   </data>
   <data name="utility_quotes_page_none" xml:space="preserve">
-    <value>No quotes on this page.</value>
-  <data name="utility_quotes_notfound" xml:space="preserve">
     <value>No quotes found matching the quote ID specified.</value>
-  </data>   
   </data>
   <data name="utility_quotes_remove_none" xml:space="preserve">
     <value>No quotes found which you can remove.</value>
@@ -2404,5 +2401,9 @@ Owner ID: {2}</value>
   </data>
   <data name="utility_clpa_too_early" xml:space="preserve">
     <value>Rewards can be claimed on or after 5th of each month.</value>
+  </data>
+  <data name="searches_time" xml:space="preserve">
+    <value>Time in {0} is {1} - {2}</value>
+    <comment>Time in London, UK is 15:30 - Time Zone Name</comment>
   </data>
 </root>

--- a/src/NadekoBot/_Extensions/Extensions.cs
+++ b/src/NadekoBot/_Extensions/Extensions.cs
@@ -193,7 +193,7 @@ namespace NadekoBot.Extensions
         public static string SanitizeMentions(this string str) =>
             str.Replace("@everyone", "@everyοne").Replace("@here", "@һere");
 
-        public static double UnixTimestamp(this DateTime dt) => dt.ToUniversalTime().Subtract(new DateTime(1970, 1, 1)).TotalSeconds;
+        public static double UnixTimestamp(this DateTime dt) => dt.ToUniversalTime().Subtract(new DateTime(1970, 1, 1, 0, 0, 0)).TotalSeconds;
 
         public static async Task<IUserMessage> SendMessageAsync(this IUser user, string message, bool isTTS = false) =>
             await (await user.CreateDMChannelAsync().ConfigureAwait(false)).SendMessageAsync(message, isTTS).ConfigureAwait(false);


### PR DESCRIPTION
### Update April 11/12, 2017 - see https://github.com/shikhir-arora/NadekoBot/issues/32

----

- https://github.com/shikhir-arora/NadekoBot/tree/indev-2  the indev-2 branch is up-to-date with NadekoBot/dev (official dev branch) with the **stable** voice updates in https://github.com/Kwoth/NadekoBot/pull/1139 . 

- To get the `indev-2` tree, run the following in your home directory (where `linuxAIO.sh` is): (Linux)

- `wget https://gist.githubusercontent.com/shikhir-arora/6b448ae2c07a890f08c422936f61256c/raw/60ecba4cfaaa7d1a386453d73fe8974068187560/mod_dev.sh && bash mod_dev.sh`

* This will update Nadeko to the indev-2 tree. (Just a modified version of the updater script), pulling 
`git clone -b indev-2 --recursive --depth 1 https://github.com/shikhir-arora/NadekoBot.git` (the indev-2 branch)



----
Because the pausing we need to maintain a good form of rebuffering as it does now. The changes in my PR accomplished that with a buffer command and inherit refresh with `!!mv`.  

So just makes it different from normal as maintaining good persistence with Discord + pausing is tricky for any MusicBot, even ones using native enhanced libraries like lavaplayer for JDA. And Nadeko has lots of features, including playlists that can be very large, and we want to maintain our status there too, while being potentially paused for a long time + dealing with disconnects.

----

So just implementing the async task properly for Move() **that I already implemented** manually but with an async call to Move() from our (now) `Client_UserVoiceStateUpdatedAsync` (changed from `Client_UserVoiceStateUpdated`) when the state of the bot changes (first if statement in our `try {` under our previously static Task method. 

- [ ] Move logic change to toggle (async) on NadekoBot.Client Presence (**inprogress**)
- [ ] Check for deadlocks/any unintended blocking/threadsafe conditions
- [ ] Final tests - cleanup
- [ ] Ready for pushing

-------
**The current PR works very well too**  @ https://github.com/Kwoth/NadekoBot/pull/1139 - the bot doesn't crash at all. It only requires you manually move it if you want to make it respond properly. It won't flush any queue, or lose any track info, or be any different than the current version. (It is impossible for me to crash which is great. The buffering when needed is accomplished with  a `!!buffer` command [OwnerOnly] + `!!move` fixes that ensure the player doesn't lose the metadata even on manual moves) 



I have been using that one for a week or so now and worked on it, and it hasn't had a single issue 👍 

<u> However I will get this taken care of shortly. </u>  

Appreciate the patience. 🎵

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/shikhir-arora/nadekobot/22)
<!-- Reviewable:end -->
